### PR TITLE
VS 2015 Clock Fixed | fix int when working with std::size_t / std::ptrdiff_t

### DIFF
--- a/include/nonius/clock.h++
+++ b/include/nonius/clock.h++
@@ -14,7 +14,7 @@
 #ifndef NONIUS_CLOCK_HPP
 #define NONIUS_CLOCK_HPP
 
-#ifdef _MSC_VER // MSVC <chrono> is borken and had little to no testing done before shipping
+#if _MSC_VER < 1900 // MSVC <chrono> is borken and had little to no testing done before shipping (Dev14/VS15 CTP fixes it)
 #include <boost/chrono.hpp>
 #else
 #include <chrono>
@@ -22,7 +22,7 @@
 #endif
 
 namespace nonius {
-#ifdef _MSC_VER // MSVC <chrono> is borken and had little to no testing done before shipping
+#if _MSC_VER < 1900 // MSVC <chrono> is borken and had little to no testing done before shipping (Dev14/VS15 CTP fixes it)
     namespace chrono = boost::chrono;
     template <unsigned Num, unsigned Den = 1>
     using ratio = boost::ratio<Num, Den>;

--- a/include/nonius/detail/argparse.h++
+++ b/include/nonius/detail/argparse.h++
@@ -68,7 +68,7 @@ namespace nonius {
         };
     
         template <typename Iterator, typename Projection>
-        int get_max_width(Iterator first, Iterator last, Projection proj) {
+        std::ptrdiff_t get_max_width(Iterator first, Iterator last, Projection proj) {
             auto it = std::max_element(first, last, [&proj](option const& a, option const& b) { return proj(a) < proj(b); });
             return proj(*it);
         }

--- a/include/nonius/detail/escape.h++
+++ b/include/nonius/detail/escape.h++
@@ -29,7 +29,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
+            std::ptrdiff_t n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
 
             std::string escaped;
             escaped.reserve(source.size() + n_magic*6);

--- a/include/nonius/reporters/csv_reporter.h++
+++ b/include/nonius/reporters/csv_reporter.h++
@@ -99,7 +99,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int quotes = std::count(first, last, '"');
+            std::ptrdiff_t quotes = std::count(first, last, '"');
             if(quotes == 0) return source;
 
             std::string escaped;

--- a/include/nonius/reporters/junit_reporter.h++
+++ b/include/nonius/reporters/junit_reporter.h++
@@ -90,7 +90,7 @@ namespace nonius {
 
             report_stream() << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
             report_stream() << "<testsuite name=\"" << escape(title) << "\" tests=\"" << data.size() << "\"";
-            int failures = std::count_if(data.begin(), data.end(),
+            std::ptrdiff_t failures = std::count_if(data.begin(), data.end(),
                     [](std::pair<std::string const&, result> const& p) {
                         return static_cast<bool>(p.second.failure);
                     });


### PR DESCRIPTION
This pull request makes x64 builds warningless for when int is not large enough to hold the std::ptrdiff_t / std::size_t returned by various std:: functions and other facilities.

This pull request also adds machinery to use the regular std::chrono namespace when using the VS 2015 chrono compilers.
