### PR TITLE
Fix all occurrences of int when working with std::size_t / std::ptrdiff_t

### DIFF
--- a/include/nonius/detail/argparse.h++
+++ b/include/nonius/detail/argparse.h++
@@ -68,7 +68,7 @@ namespace nonius {
         };
     
         template <typename Iterator, typename Projection>
-        int get_max_width(Iterator first, Iterator last, Projection proj) {
+        std::ptrdiff_t get_max_width(Iterator first, Iterator last, Projection proj) {
             auto it = std::max_element(first, last, [&proj](option const& a, option const& b) { return proj(a) < proj(b); });
             return proj(*it);
         }

--- a/include/nonius/detail/escape.h++
+++ b/include/nonius/detail/escape.h++
@@ -29,7 +29,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
+            std::ptrdiff_t n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
 
             std::string escaped;
             escaped.reserve(source.size() + n_magic*6);

--- a/include/nonius/reporters/csv_reporter.h++
+++ b/include/nonius/reporters/csv_reporter.h++
@@ -99,7 +99,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int quotes = std::count(first, last, '"');
+            std::ptrdiff_t quotes = std::count(first, last, '"');
             if(quotes == 0) return source;
 
             std::string escaped;

--- a/include/nonius/reporters/junit_reporter.h++
+++ b/include/nonius/reporters/junit_reporter.h++
@@ -90,7 +90,7 @@ namespace nonius {
 
             report_stream() << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
             report_stream() << "<testsuite name=\"" << escape(title) << "\" tests=\"" << data.size() << "\"";
-            int failures = std::count_if(data.begin(), data.end(),
+            std::ptrdiff_t failures = std::count_if(data.begin(), data.end(),
                     [](std::pair<std::string const&, result> const& p) {
                         return static_cast<bool>(p.second.failure);
                     });


### PR DESCRIPTION
The only integral type that supports changing what it returns in response to the sizes of containers and other things used seems to be std::ptrdiff_t (that's signed: std::size_t is unsigned). There does not seem to be another integer alias: if it's acceptable, perhaps a static_cast that will purposefully convert to `int` or using `auto` everywhere can avoid the issue (though in some cases that may be undesirable: some things return std::size_t, and so the `auto` would resolved to an unsigned type that may trigger underflow if the number goes negative).
