### PR TITLE
Fixed compile warnings under VS 2013 x64

### DIFF
--- a/include/nonius/detail/argparse.h++
+++ b/include/nonius/detail/argparse.h++
@@ -70,7 +70,7 @@ namespace nonius {
         template <typename Iterator, typename Projection>
         int get_max_width(Iterator first, Iterator last, Projection proj) {
             auto it = std::max_element(first, last, [&proj](option const& a, option const& b) { return proj(a) < proj(b); });
-            return proj(*it);
+            return static_cast<int>(proj(*it));
         }
 
         inline std::ostream& operator<<(std::ostream& os, help_text h) {

--- a/include/nonius/detail/escape.h++
+++ b/include/nonius/detail/escape.h++
@@ -29,7 +29,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
+            auto n_magic = std::count_if(first, last, [&magic](char c) { return magic.find(c) != std::string::npos; });
 
             std::string escaped;
             escaped.reserve(source.size() + n_magic*6);

--- a/include/nonius/detail/stats.h++
+++ b/include/nonius/detail/stats.h++
@@ -39,9 +39,9 @@ namespace nonius {
 
         template <typename Iterator>
         double weighted_average_quantile(int k, int q, Iterator first, Iterator last) {
-            int count = last - first;
-            double idx = (count - 1) * k /(double) q;
-            int j = (int)idx;
+            auto count = last - first;
+            double idx = (count - 1) * k /static_cast<double>(q);
+            int j = static_cast<int>(idx);
             double g = idx - j;
             std::nth_element(first, first+j, last);
             auto xj = first[j];
@@ -77,7 +77,7 @@ namespace nonius {
 
         template <typename Iterator>
         double mean(Iterator first, Iterator last) {
-            int count = last - first;
+            auto count = last - first;
             double sum = std::accumulate(first, last, 0.);
             return sum / count;
         }
@@ -94,8 +94,8 @@ namespace nonius {
 
         template <typename URng, typename Iterator, typename Estimator>
         sample resample(URng& rng, int resamples, Iterator first, Iterator last, Estimator& estimator) {
-            int n = last - first;
-            std::uniform_int_distribution<int> dist(0, n-1);
+            auto n = last - first;
+            std::uniform_int_distribution<decltype(n)> dist(0, n-1);
 
             sample out;
             out.reserve(resamples);
@@ -111,7 +111,7 @@ namespace nonius {
 
         template <typename Estimator, typename Iterator>
         sample jackknife(Estimator&& estimator, Iterator first, Iterator last) {
-            int n = last - first;
+            auto n = last - first;
             auto second = std::next(first);
             sample results;
             results.reserve(n);
@@ -128,7 +128,7 @@ namespace nonius {
         estimate<double> bootstrap(double confidence_level, Iterator first, Iterator last, sample const& resample, Estimator&& estimator) {
             namespace bm = boost::math;
 
-            int n_samples = last - first;
+            auto n_samples = last - first;
 
             double point = estimator(first, last);
             sample jack = jackknife(estimator, first, last);
@@ -142,7 +142,7 @@ namespace nonius {
                     });
 
             double accel = sum_cubes / (6 * std::pow(sum_squares, 1.5));
-            int n = resample.size();
+            int n = static_cast<int>(resample.size());
             double prob_n = std::count_if(resample.begin(), resample.end(), [point](double x) { return x < point; }) /(double) n;
             double bias = bm::quantile(bm::normal{}, prob_n);
             double z1 = bm::quantile(bm::normal{}, (1. - confidence_level) / 2.);
@@ -153,14 +153,14 @@ namespace nonius {
             double b2 = bias - z1;
             double a1 = a(b1);
             double a2 = a(b2);
-            int lo = std::max(cumn(a1), 0);
-            int hi = std::min(cumn(a2), n - 1);
+            auto lo = std::max(cumn(a1), 0);
+            auto hi = std::min(cumn(a2), n - 1);
 
             if(n_samples == 1) return { point, point, point, confidence_level };
             else return { point, resample[lo], resample[hi], confidence_level };
         }
 
-        inline double outlier_variance(estimate<double> mean, estimate<double> stddev, int n) {
+        inline double outlier_variance(estimate<double> mean, estimate<double> stddev, std::size_t n) {
             double sb = stddev.point;
             double mn = mean.point / n;
             double mg_min = mn / 2.;
@@ -172,7 +172,7 @@ namespace nonius {
                 double k = mn - x;
                 double d = k * k;
                 double nd = n * d;
-                double k0 = -n * nd;
+                double k0 = (-1) * n * nd;
                 double k1 = sb2 - n * sg2 + nd;
                 double det = k1 * k1 - 4 * sg2 * k0;
                 return (int)(-2. * k0 / (k1 + std::sqrt(det)));
@@ -196,7 +196,7 @@ namespace nonius {
         bootstrap_analysis analyse_samples(double confidence_level, int n_resamples, Iterator first, Iterator last) {
             static std::random_device entropy;
 
-            int n = last - first;
+            auto n = last - first;
 
             auto mean = &detail::mean<Iterator>;
             auto stddev = &detail::standard_deviation<Iterator>;

--- a/include/nonius/reporters/csv_reporter.h++
+++ b/include/nonius/reporters/csv_reporter.h++
@@ -99,7 +99,7 @@ namespace nonius {
             auto first = source.begin();
             auto last = source.end();
 
-            int quotes = std::count(first, last, '"');
+            auto quotes = std::count(first, last, '"');
             if(quotes == 0) return source;
 
             std::string escaped;

--- a/include/nonius/reporters/junit_reporter.h++
+++ b/include/nonius/reporters/junit_reporter.h++
@@ -90,7 +90,7 @@ namespace nonius {
 
             report_stream() << "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
             report_stream() << "<testsuite name=\"" << escape(title) << "\" tests=\"" << data.size() << "\"";
-            int failures = std::count_if(data.begin(), data.end(),
+            auto failures = std::count_if(data.begin(), data.end(),
                     [](std::pair<std::string const&, result> const& p) {
                         return static_cast<bool>(p.second.failure);
                     });


### PR DESCRIPTION
This will remove the compile warnings under Visual Studio 2013 x64.
REMARK: This was not tested with g++
