### PR TITLE
Allow disabling of extra reporters with the preprocessor

### DIFF
--- a/include/nonius/nonius.h++
+++ b/include/nonius/nonius.h++
@@ -22,9 +22,18 @@
 #include <nonius/go.h++>
 
 #include <nonius/reporters/standard_reporter.h++>
+
+#ifndef NONIUS_DISABLE_EXTRA_REPORTERS
+#ifndef NONIUS_DISABLE_CSV_REPORTER
 #include <nonius/reporters/csv_reporter.h++>
+#endif // NONIUS_DISABLE_CSV_REPORTER
+#ifndef NONIUS_DISABLE_JUNIT_REPORTER
 #include <nonius/reporters/junit_reporter.h++>
+#endif // NONIUS_DISABLE_JUNIT_REPORTER
+#ifndef NONIUS_DISABLE_HTML_REPORTER
 #include <nonius/reporters/html_reporter.h++>
+#endif // NONIUS_DISABLE_HTML_REPORTER
+#endif // NONIUS_DISABLE_EXTRA_REPORTERS
 
 #endif // NONIUS_HPP
 


### PR DESCRIPTION
This allows for disabling some heavy reporters as mentioned in chat
such as the HTML reporter. Extra reporters are considered reporters
that aren't the 'standard' reporter.

You can either disable them individually or disable them all with a
single macro, `NONIUS_DISABLE_EXTRA_REPORTERS`.
