### PR TITLE
Remove boost variant

### DIFF
--- a/examples/example1.c++
+++ b/examples/example1.c++
@@ -1,4 +1,4 @@
-#include <nonius.h++>
+#include <nonius/nonius.h++>
 
 #include <iterator>
 #include <string>

--- a/examples/example2.c++
+++ b/examples/example2.c++
@@ -1,4 +1,4 @@
-#include <nonius.h++>
+#include <nonius/nonius.h++>
 
 #include <iterator>
 #include <string>

--- a/examples/example3.c++
+++ b/examples/example3.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius/nonius.h++>
 
 NONIUS_BENCHMARK("to_string(42)", []{
     return std::to_string(42);

--- a/examples/example3.c++
+++ b/examples/example3.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius/nonius.h++>
+#include <nonius/nonius_single.h++>
 
 NONIUS_BENCHMARK("to_string(42)", []{
     return std::to_string(42);

--- a/examples/example4.c++
+++ b/examples/example4.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius/nonius.h++>
 
 #include <list>
 #include <forward_list>

--- a/examples/example4.c++
+++ b/examples/example4.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius/nonius.h++>
+#include <nonius/nonius_single.h++>
 
 #include <list>
 #include <forward_list>

--- a/examples/example5.c++
+++ b/examples/example5.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius/nonius.h++>
+#include <nonius/nonius_single.h++>
 
 #include <string>
 #include <vector>

--- a/examples/example5.c++
+++ b/examples/example5.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius/nonius.h++>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
Replace's boost::variant with a std::function removing the dependency on Boost.Variant.

Caveat: using a std::shared_ptr is not the same as using an std::unique_ptr but the overhead is on construction only. Since std::function requires CopyConstructible, this is the simplest thing I found that works.

I also updated the header of some examples again to include nonius_single.h++ since they were missing the main function.
