### PR TITLE
Don't define main() unless NONIUS_RUNNER is defined

### DIFF
--- a/include/nonius/main.h++
+++ b/include/nonius/main.h++
@@ -177,9 +177,11 @@ namespace nonius {
     }
 }
 
+#ifdef NONIUS_RUNNER
 int main(int argc, char** argv) {
     return nonius::main(argc, argv);
 }
+#endif // NONIUS_RUNNER
 
 #endif // NONIUS_MAIN_HPP
 

--- a/include/nonius/nonius_single.h++
+++ b/include/nonius/nonius_single.h++
@@ -12,7 +12,4 @@
 // Single header root
 
 #include <nonius/nonius.h++>
-
-#ifdef NONIUS_RUNNER
 #include <nonius/main.h++>
-#endif // NONIUS_RUNNER


### PR DESCRIPTION
This allows a custom main() function to call nonius::main(), which is useful if
some initialization code needs to run before the benchmarks. Previously,
main.h++ couldn't be included because main() would then be defined twice.
