### PR TITLE
fix include for examples that do not provide main

### DIFF
--- a/examples/example1.c++
+++ b/examples/example1.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius_single.h++>
 
 NONIUS_BENCHMARK("to_string(42)", []{
     return std::to_string(42);

--- a/examples/example2.c++
+++ b/examples/example2.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius_single.h++>
 
 #include <list>
 #include <forward_list>

--- a/examples/example3.c++
+++ b/examples/example3.c++
@@ -1,5 +1,5 @@
 #define NONIUS_RUNNER
-#include <nonius.h++>
+#include <nonius_single.h++>
 
 #include <string>
 #include <vector>


### PR DESCRIPTION
examples where not linking due to missing main
since they probably should only demonstrate the most simple solution, it seems good to use the provided main routine.
