### PR TITLE
filter benchmarks to execute at runtime

### DIFF
--- a/include/nonius/configuration.h++
+++ b/include/nonius/configuration.h++
@@ -25,6 +25,7 @@ namespace nonius {
         std::string title = "benchmarks";
         std::string output_file;
         std::string reporter;
+        std::string filter_pattern = ".*";
         bool list_benchmarks = false;
         bool list_reporters = false;
         bool no_analysis = false;

--- a/include/nonius/go.h++
+++ b/include/nonius/go.h++
@@ -29,6 +29,7 @@
 #include <exception>
 #include <iostream>
 #include <utility>
+#include <regex>
 
 namespace nonius {
     namespace detail {
@@ -74,8 +75,15 @@ namespace nonius {
 
         rep.suite_start();
 
+        // create the regex that matches benchmark names
+        std::regex benchmark_pattern_matcher(cfg.filter_pattern);
+
         for(; first != last; ++first) {
             try {
+                // if the benchmark name does not match the regex pattern then skip it
+                if( !std::regex_match(first->name, benchmark_pattern_matcher) )
+                    continue;
+
                 rep.benchmark_start(first->name);
 
                 auto plan = user_code(rep, [&first, &cfg, &env]{ return first->template prepare<Clock>(cfg, env); });

--- a/include/nonius/main.h++
+++ b/include/nonius/main.h++
@@ -72,10 +72,11 @@ namespace nonius {
                 detail::option("reporter", "r", "reporter to use (default: standard)", "REPORTER"),
                 detail::option("title", "t", "set report title", "TITLE"),
                 detail::option("no-analysis", "A", "perform only measurements; do not perform any analysis"),
+                detail::option("filter", "f", "only run benchmarks whose name matches the regular expression pattern", "PATTERN"),
                 detail::option("list", "l", "list benchmarks"),
                 detail::option("list-reporters", "lr", "list available reporters"),
                 detail::option("verbose", "v", "show verbose output (mutually exclusive with -q)"),
-                detail::option("summary", "q", "show summary output (mutually exclusive with -v)"),
+                detail::option("summary", "q", "show summary output (mutually exclusive with -v)")
             };
             return the_options;
         }
@@ -98,6 +99,7 @@ namespace nonius {
                 parse(cfg.output_file, args, "output");
                 parse(cfg.reporter, args, "reporter", is_reporter);
                 parse(cfg.no_analysis, args, "no-analysis");
+                parse(cfg.filter_pattern, args, "filter");
                 parse(cfg.list_benchmarks, args, "list");
                 parse(cfg.list_reporters, args, "list-reporters");
                 parse(cfg.verbose, args, "verbose");


### PR DESCRIPTION
I've added the ability to filter which benchmarks you want to run as a command line option.

the --filter (and -f) option allows you to define a regex pattern that benchmark names must match to be executed. The default pattern is ".*" which will run all tests.
