### PR TITLE
Compile fix for MSVC2015

### DIFF
--- a/include/nonius/execution_plan.h++
+++ b/include/nonius/execution_plan.h++
@@ -46,7 +46,7 @@ namespace nonius {
             std::generate_n(std::back_inserter(times), cfg.samples, [this, env]{
                     detail::chronometer_model<Clock> model;
                     detail::optimizer_barrier();
-                    benchmark(chronometer(model, iterations_per_sample, params));
+                    this->benchmark(chronometer(model, iterations_per_sample, params));
                     detail::optimizer_barrier();
                     auto sample_time = model.elapsed() - env.clock_cost.mean;
                     if(sample_time < FloatDuration<Clock>::zero()) sample_time = FloatDuration<Clock>::zero();


### PR DESCRIPTION
Fixes the following error:

```
include\nonius/execution_plan.h++(49): error C2440: '<function-style-cast>': cannot convert from 'nonius::chronometer' to 'nonius::benchmark'
include\nonius/execution_plan.h++(49): note: No constructor could take the source type, or constructor overload resolution was ambiguous
test\faster_than_clock.c++(33): note: see reference to function template instantiation 'std::vector<std::chrono::duration<double,std::nano>,std::allocator<_Ty>> nonius::execution_plan<nonius::counting_clock::duration>::run<nonius::counting_clock>(nonius::configuration,nonius::environment<std::chrono::duration<double,std::nano>>) const' being compiled
        with
        [
            _Ty=std::chrono::duration<double,std::nano>
        ]
test\faster_than_clock.c++(33): note: see reference to function template instantiation 'std::vector<std::chrono::duration<double,std::nano>,std::allocator<_Ty>> nonius::execution_plan<nonius::counting_clock::duration>::run<nonius::counting_clock>(nonius::configuration,nonius::environment<std::chrono::duration<double,std::nano>>) const' being compiled
        with
        [
            _Ty=std::chrono::duration<double,std::nano>
        ]
```
