### PR TITLE
Fix for multiply defined symbols on g++

### DIFF
--- a/include/nonius/go.h++
+++ b/include/nonius/go.h++
@@ -67,7 +67,7 @@ namespace nonius {
         }
     }
 
-    std::vector<parameters> generate_params(param_configuration cfg) {
+    inline std::vector<parameters> generate_params(param_configuration cfg) {
         auto params = global_param_registry().defaults().merged(cfg.map);
         if (!cfg.run) {
             return {params};


### PR DESCRIPTION
I was getting this when including nonius.h++ in multiple cpp files.

```
CMakeFiles/bench.dir/main.cpp.o: In function `nonius::generate_params(nonius::param_configuration)':
main.cpp:(.text+0x369): multiple definition of `nonius::generate_params(nonius::param_configuration)'
CMakeFiles/bench.dir/bench1.cpp.o:bench1.cpp:(.text+0x369): first defined here
```

`main.cpp`:

```
#define NONIUS_RUNNER
#include <nonius.h++>
```

`bench.cpp`:

```
#include <nonius.h++>

NONIUS_BENCHMARK("to_string(42)", []{
    return std::to_string(42);
})

NONIUS_BENCHMARK("to_string(4.2)", []{
    return std::to_string(4.2);
})
```
