### PR TITLE
Make Clock propagate correctly across functions

### DIFF
--- a/include/nonius/detail/measure.h++
+++ b/include/nonius/detail/measure.h++
@@ -22,7 +22,7 @@
 
 namespace nonius {
     namespace detail {
-        template <typename Clock = default_clock, typename Fun, typename... Args>
+        template <typename Clock, typename Fun, typename... Args>
         TimingOf<Clock, Fun(Args...)> measure(Fun&& fun, Args&&... args) {
             auto start = Clock::now();
             auto&& r = detail::complete_invoke(fun, std::forward<Args>(args)...);

--- a/include/nonius/detail/run_for_at_least.h++
+++ b/include/nonius/detail/run_for_at_least.h++
@@ -47,7 +47,7 @@ namespace nonius {
             }
         };
 
-        template <typename Clock = default_clock, typename Fun>
+        template <typename Clock, typename Fun>
         TimingOf<Clock, Fun(run_for_at_least_argument_t<Clock, Fun>)> run_for_at_least(const parameters& params, Duration<Clock> how_long, int seed, Fun&& fun) {
             auto iters = seed;
             while(iters < (1 << 30)) {

--- a/include/nonius/environment.h++
+++ b/include/nonius/environment.h++
@@ -28,7 +28,7 @@ namespace nonius {
             return { mean, outliers };
         }
     };
-    template <typename Clock = default_clock>
+    template <typename Clock>
     struct environment {
         using clock_type = Clock;
         environment_estimate<FloatDuration<Clock>> clock_resolution;

--- a/include/nonius/go.h++
+++ b/include/nonius/go.h++
@@ -159,7 +159,7 @@ namespace nonius {
     }
     template <typename Clock = default_clock, typename Iterator>
     void go(configuration cfg, Iterator first, Iterator last, reporter&& rep) {
-        go(cfg, first, last, rep);
+        go<Clock>(cfg, first, last, rep);
     }
     struct no_such_reporter : virtual std::exception {
         char const* what() const NONIUS_NOEXCEPT override {
@@ -170,8 +170,8 @@ namespace nonius {
     void go(configuration cfg, benchmark_registry& benchmarks = global_benchmark_registry(), reporter_registry& reporters = global_reporter_registry()) {
         auto it = reporters.find(cfg.reporter);
         if(it == reporters.end()) throw no_such_reporter();
-        validate_benchmarks(benchmarks.begin(), benchmarks.end());
-        go(cfg, benchmarks.begin(), benchmarks.end(), *it->second);
+        validate_benchmarks<Clock>(benchmarks.begin(), benchmarks.end());
+        go<Clock>(cfg, benchmarks.begin(), benchmarks.end(), *it->second);
     }
 } // namespace nonius
 


### PR DESCRIPTION
This addresses an problem found in #74, but it doesn't address the underlying problem that
occurs with the default_clock. That needs to be investigated further.
