### PR TITLE
Initialize duration struct members to fix uninitialized data on Windows

### DIFF
--- a/include/nonius/detail/timing.h++
+++ b/include/nonius/detail/timing.h++
@@ -23,9 +23,22 @@
 namespace nonius {
     template <typename Duration, typename Result>
     struct timing {
-        Duration elapsed;
+        Duration elapsed = Duration::zero();
         Result result;
-        int iterations;
+        int iterations = 0;
+
+        timing() = default;
+
+        timing(Duration elapsed, Result result, int iterations)
+            : elapsed(elapsed)
+            , result(result)
+            , iterations(iterations)
+        {}
+
+        template <typename Duration2>
+        operator timing<Duration2, Result>() const {
+            return timing<Duration2, Result>{ chrono::duration_cast<Duration2>(elapsed), result, iterations };
+        }
     };
     template <typename Clock, typename Sig>
     using TimingOf = timing<Duration<Clock>, detail::CompleteType<detail::ResultOf<Sig>>>;

--- a/include/nonius/detail/timing.h++
+++ b/include/nonius/detail/timing.h++
@@ -23,7 +23,7 @@
 namespace nonius {
     template <typename Duration, typename Result>
     struct timing {
-        Duration elapsed = Duration::zero();
+        Duration elapsed = {};
         Result result;
         int iterations = 0;
 

--- a/include/nonius/environment.h++
+++ b/include/nonius/environment.h++
@@ -20,8 +20,15 @@
 namespace nonius {
     template <typename Duration>
     struct environment_estimate {
-        Duration mean;
+        Duration mean = Duration::zero();
         outlier_classification outliers;
+
+        environment_estimate() = default;
+
+        environment_estimate(Duration mean, outlier_classification outliers)
+            : mean(mean)
+            , outliers(outliers)
+        {}
 
         template <typename Duration2>
         operator environment_estimate<Duration2>() const {

--- a/include/nonius/environment.h++
+++ b/include/nonius/environment.h++
@@ -20,7 +20,7 @@
 namespace nonius {
     template <typename Duration>
     struct environment_estimate {
-        Duration mean = Duration::zero();
+        Duration mean = {};
         outlier_classification outliers;
 
         environment_estimate() = default;

--- a/include/nonius/estimate.h++
+++ b/include/nonius/estimate.h++
@@ -17,14 +17,23 @@
 namespace nonius {
     template <typename Duration>
     struct estimate {
-        Duration point;
-        Duration lower_bound;
-        Duration upper_bound;
-        double confidence_interval;
+        Duration point = Duration::zero();
+        Duration lower_bound = Duration::zero();
+        Duration upper_bound = Duration::zero();
+        double confidence_interval = 0.0;
+
+        estimate() = default;
+
+        estimate(Duration point, Duration lower_bound, Duration upper_bound, double confidence_interval)
+            : point(point)
+            , lower_bound(lower_bound)
+            , upper_bound(upper_bound)
+            , confidence_interval(confidence_interval)
+        {}
 
         template <typename Duration2>
         operator estimate<Duration2>() const {
-            return { point, lower_bound, upper_bound, confidence_interval };
+            return estimate<Duration2>{ point, lower_bound, upper_bound, confidence_interval };
         }
     };
 } // namespace nonius

--- a/include/nonius/estimate.h++
+++ b/include/nonius/estimate.h++
@@ -17,9 +17,9 @@
 namespace nonius {
     template <typename Duration>
     struct estimate {
-        Duration point = Duration::zero();
-        Duration lower_bound = Duration::zero();
-        Duration upper_bound = Duration::zero();
+        Duration point = {};
+        Duration lower_bound = {};
+        Duration upper_bound = {};
         double confidence_interval = 0.0;
 
         estimate() = default;

--- a/include/nonius/execution_plan.h++
+++ b/include/nonius/execution_plan.h++
@@ -24,16 +24,27 @@
 namespace nonius {
     template <typename Duration>
     struct execution_plan {
-        int iterations_per_sample;
-        Duration estimated_duration;
+        int iterations_per_sample = 0;
+        Duration estimated_duration = Duration::zero();
         parameters params;
         detail::benchmark_function benchmark;
-        Duration warmup_time;
-        int warmup_iterations;
+        Duration warmup_time = Duration::zero();
+        int warmup_iterations = 0;
+
+        execution_plan() = default;
+
+        execution_plan(int iterations_per_sample, Duration estimated_duration, parameters params, detail::benchmark_function benchmark, Duration warmup_time, int warmup_iterations)
+            : iterations_per_sample(iterations_per_sample)
+            , estimated_duration(estimated_duration)
+            , params(params)
+            , benchmark(benchmark)
+            , warmup_time(warmup_time)
+            , warmup_iterations(warmup_iterations)
+        {}
 
         template <typename Duration2>
         operator execution_plan<Duration2>() const {
-            return { iterations_per_sample, estimated_duration, params, benchmark, warmup_time, warmup_iterations };
+            return execution_plan<Duration2>{ iterations_per_sample, estimated_duration, params, benchmark, warmup_time, warmup_iterations };
         }
 
         template <typename Clock>

--- a/include/nonius/execution_plan.h++
+++ b/include/nonius/execution_plan.h++
@@ -25,10 +25,10 @@ namespace nonius {
     template <typename Duration>
     struct execution_plan {
         int iterations_per_sample = 0;
-        Duration estimated_duration = Duration::zero();
+        Duration estimated_duration = {};
         parameters params;
         detail::benchmark_function benchmark;
-        Duration warmup_time = Duration::zero();
+        Duration warmup_time = {};
         int warmup_iterations = 0;
 
         execution_plan() = default;


### PR DESCRIPTION
Fixes #74. Initially I just changed `execution_plan` but I've changed the rest for good measure. Unfortunately adding default member initializers means constructors need to be added and called from the conversion cast operator. I tried calling `Duration::zero()` instead of using `= {}` but MSVC seemed to get confused with the template alias `nonius::Duration` in some places.
