### PR TITLE
Fix warning in MSVC.

### DIFF
--- a/include/nonius/detail/argparse.h++
+++ b/include/nonius/detail/argparse.h++
@@ -39,11 +39,11 @@ namespace nonius {
             bool matches_long(std::string const& s) const {
                 return std::get<0>(long_separator(s));
             }
-            bool matches_long(std::string const& s, std::string& argument) const {
+            bool matches_long(std::string const& s, std::string& arg) const {
                 bool match; std::string::const_iterator it;
                 std::tie(match, it) = long_separator(s);
                 if(match && it != s.end()) {
-                    if(*it == '=') argument.assign(it+1, s.end());
+                    if(*it == '=') arg.assign(it+1, s.end());
                     else return false;
                 }
                 return match;


### PR DESCRIPTION
I don't get this warning when building test or examples but I do when I use nonius in my own project. Not sure why but it's an easy fix.

```
warning C4458: declaration of 'argument' hides class member
```