### PR TITLE
Fix junit_reporter XML output

### DIFF
--- a/include/nonius/reporters/junit_reporter.h++
+++ b/include/nonius/reporters/junit_reporter.h++
@@ -30,6 +30,7 @@
 #include <limits>
 #include <unordered_map>
 #include <vector>
+#include <utility>
 #include <exception>
 
 namespace nonius {
@@ -98,9 +99,9 @@ namespace nonius {
             report_stream() << ">\n";
 
             report_stream() << " <properties>\n";
-            report_stream() << "  <property name=\"samples\" value=\"" << n_samples << "\">\n";
-            report_stream() << "  <property name=\"confidence_interval\" value=\"" << std::setprecision(3) << confidence_interval << "\">\n";
-            report_stream() << "  <property name=\"resamples\" value=\"" << resamples << "\">\n";
+            report_stream() << "  <property name=\"samples\" value=\"" << n_samples << "\"></property>\n";
+            report_stream() << "  <property name=\"confidence_interval\" value=\"" << std::setprecision(3) << confidence_interval << "\"></property>\n";
+            report_stream() << "  <property name=\"resamples\" value=\"" << resamples << "\"></property>\n";
             report_stream() << " </properties>\n";
 
             for(auto tc : data) {


### PR DESCRIPTION
I came across this error during Jenkins JUnit integration of my benchmarks: 

org.xml.sax.SAXParseException; systemId: file:/data/jenkins/jobs/CoreEngine-PT-Tests/builds/23/performance-reports/JUnit/perf_result.xml; lineNumber: 7; columnNumber: 4; The element type "property" must be terminated by the matching end-tag "</property>".

This commit have fixed the issue. 
You may not accept it since I have only tested it with JUnit Jenkins parser and it may not works with other parsers.  