### PR TITLE
fix: NONIUS_RUNNER generates main()

### DIFF
--- a/include/nonius/nonius.h++
+++ b/include/nonius/nonius.h++
@@ -37,4 +37,8 @@
 #endif // NONIUS_DISABLE_HTML_REPORTER
 #endif // NONIUS_DISABLE_EXTRA_REPORTERS
 
+#ifdef NONIUS_RUNNER
+#include <nonius/main.h++>
+#endif // NONIUS_RUNNER
+
 #endif // NONIUS_HPP


### PR DESCRIPTION
Despite this:
`#define NONIUS_RUNNER

#include <nonius.h++>`
...main() was not being generated by the examples.

Signed-off-by: Jesse Williamson <jwilliamson@suse.de>