### PR TITLE
Added cast to remove conversion warning (VS 15.5)

### DIFF
--- a/include/nonius/detail/estimate_clock.h++
+++ b/include/nonius/detail/estimate_clock.h++
@@ -84,7 +84,7 @@ namespace nonius {
             int nsamples = static_cast<int>(std::ceil(time_limit / r.elapsed));
             times.reserve(nsamples);
             std::generate_n(std::back_inserter(times), nsamples, [time_clock, &r]{
-                        return (time_clock(r.iterations) / r.iterations).count();
+                        return static_cast<double>((time_clock(r.iterations) / r.iterations).count());
                     });
             return {
                 FloatDuration<Clock>(mean(times.begin(), times.end())),


### PR DESCRIPTION
Warning C4244 'argument': conversion from '__int64' to 'double', possible loss of data