### PR TITLE
Directly construct stringstream without copy/move

### DIFF
--- a/include/nonius/param.h++
+++ b/include/nonius/param.h++
@@ -100,7 +100,7 @@ public:
     friend bool operator==(const param& x, const param& y) { return x.impl_->eq(y); }
 
     param parse(std::string const& s) const {
-        auto ss = std::stringstream{s};
+        std::stringstream ss{s};
         auto cpy = *this;
         ss.exceptions(std::ios::failbit);
         ss >> cpy;


### PR DESCRIPTION
The libstdc++ bundled with G++ 4.8.1 on OpenSUSE 13.1 does not have a move constructor for std::stringstream, and copying is forbidden. Work around this by constructing the std::stringstream directly.